### PR TITLE
Env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 __pycache__
+
+#ignode intellij
+.idea
+
+#environment file
+.env

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ cd data-quality
 $ to be documented
 ```
 
-# Create a .evn file 
+# Create a .evn file in project root
 This file is used to define and your docker parameters - app paths, passwords, secrets. For example if your project is stored in machine root:
 ```
 DB_DATA_VOLUME_PATH=./db/data/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ $ cd data-quality
 $ to be documented
 ```
 
+# Create a .evn file 
+This file is used to define and your docker parameters - app paths, passwords, secrets. For example if your project is stored in machine root:
+```
+DB_DATA_VOLUME_PATH=./db/data/
+SCRIPT_VOLUME_PATH=./scripts
+API_VOLUME_PATH=./api
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_DATABASE=public
+DATABASE_URL=postgres://postgres:password@db:5433/data_quality
+```
 # Start Your Instance
 To start all the services of the data quality framework, execute the following commands in a terminal window. It will automatically create the Docker images and run the Docker containers.
 ```shellsession

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,6 @@ services:
       - db
     env_file:
       - ./.env 
-    environment: 
-      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5433/{POSTGRES_DATABASE}
     expose:
       - 5433
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,11 @@ services:
     image: data-quality-db
     build:
       context: ./db
-    volumes:
-      - ./db/data/:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password  # To be moved to environment file
-      POSTGRES_DATABASE: public
+#    volumes:
+#      - $DB_DATA_VOLUME_PATH:/var/lib/postgresql/data
+#      - ./db/data/:/var/lib/postgresql/data
+    env_file:
+        - ./.env
     expose:
       - 5432
     ports:
@@ -26,18 +25,20 @@ services:
     image: graphile/postgraphile
     depends_on:
       - db
-    environment:
-      DATABASE_URL: postgres://postgres:password@db:5432/data_quality # To be moved to environment file
+    env_file:
+      - ./.env 
+    environment: 
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5433/{POSTGRES_DATABASE}
     expose:
       - 5433
     ports:
       - 5433:5433
-    command: ["postgraphile", "--connection", $DATABASE_URL, "--host", "0.0.0.0", "--port", "5433", "--schema", "base"]
+    command: ["postgraphile", "--connection", "${DATABASE_URL}", "--host", "0.0.0.0", "--port", "5433", "--schema", "base"]
     links:
       - db
     networks:
       - data-quality-network
-
+      
   scripts:
     container_name: data-quality-scripts
     restart: always
@@ -45,7 +46,7 @@ services:
     build:
       context: ./scripts
     volumes:
-       - ./scripts:/srv/scripts
+       - $SCRIPT_VOLUME_PATH:/srv/scripts
     expose:
       - 5434
     ports:
@@ -65,7 +66,7 @@ services:
     build:
       context: ./api
     volumes:
-      - ./api:/srv/api/
+      - $API_VOLUME_PATH:/srv/api/
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       FLASK_APP: api.py
@@ -82,6 +83,6 @@ services:
       - graphql
     networks:
       - data-quality-network
-
+      
 networks:
   data-quality-network:


### PR DESCRIPTION
Added .env file support and relevant documentation to the readme file. 
This file cannot be added to git as every system can potentially use their own file (mine uses different paths to mount volumes).

Also: 
Windows (virtual box is cashing when postgresql is using an external data volume. Do you think we can avoid using it? 

More on it here: 
https://stackoverflow.com/questions/45632593/postgres-docker-container-data-fails-to-mount-to-local